### PR TITLE
correct indent (tab mixed with spaces)

### DIFF
--- a/main.py
+++ b/main.py
@@ -47,7 +47,7 @@ class Window(Gtk.Window):
         myG = G213Colors
         myG.connectG()
         myG.sendCycleCommand(self.sbGetValue(self.sbCycle))
-    	myG.saveData(myG.cycleCommand.format(str(format(self.sbGetValue(self.sbCycle), '04x'))))
+        myG.saveData(myG.cycleCommand.format(str(format(self.sbGetValue(self.sbCycle), '04x'))))
         myG.disconnectG()
 
     def sendSegments(self):
@@ -142,18 +142,18 @@ class Window(Gtk.Window):
 
 
 if "-t" in option:
-	myG = G213Colors
-	myG.connectG()
-	file = open(myG.confFile, "r") 
-	commands = file.readline().split(',')
-	for command in commands:
-		print command
-		myG.sendData(command)
-		sleep(0.01)
+    myG = G213Colors
+    myG.connectG()
+    file = open(myG.confFile, "r") 
+    commands = file.readline().split(',')
+    for command in commands:
+        print command
+        myG.sendData(command)
+        sleep(0.01)
 
-	myG.disconnectG()
-	sys.exit(0)
-
+    myG.disconnectG()
+    sys.exit(0)
+but 
 win = Window()
 win.connect("delete-event", Gtk.main_quit)
 win.show_all()


### PR DESCRIPTION
This program should not have worked as is : There was a TAB instead of SPACEs in line 50.

There also were other TABs after line 145 which shouldn't have caused problems since they were consistent, 
however, I also changed them because they were not in accord with the rest of the code, nor with pep8 style recommendation.